### PR TITLE
Add screenspot eval scripts

### DIFF
--- a/orby/data/convert_screenspot.py
+++ b/orby/data/convert_screenspot.py
@@ -21,6 +21,8 @@ import os
 import logging
 
 import datasets
+from datasets import Sequence
+from datasets import Image as ImageData
 from PIL import Image
 from transformers import AutoProcessor
 from qwen_vl_utils import smart_resize
@@ -116,7 +118,10 @@ if __name__ == "__main__":
 
         return process_fn
 
-    test_dataset = test_dataset.map(function=make_map_fn("test"), with_indices=True)
+    test_dataset = test_dataset.map(
+        function=make_map_fn("test"), with_indices=True, num_proc=16
+    )
+    test_dataset = test_dataset.cast_column("images", Sequence(ImageData()))
 
     local_dir = os.path.expanduser(args.local_dir)
     os.makedirs(local_dir, exist_ok=True)

--- a/orby/data/convert_screenspot.py
+++ b/orby/data/convert_screenspot.py
@@ -1,0 +1,128 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Preprocess the Screenspot dataset to parquet format
+"""
+
+import argparse
+import io
+import os
+import logging
+
+import datasets
+from PIL import Image
+from transformers import AutoProcessor
+from qwen_vl_utils import smart_resize
+
+from verl.utils.hdfs_io import copy, makedirs
+
+
+MODEL_PATH = "Qwen/Qwen2.5-VL-7B-Instruct"
+PROCESSOR = AutoProcessor.from_pretrained(MODEL_PATH)
+
+
+def get_resized_wh(image):
+    """
+    Get the resized width and height of the image.
+    """
+    resized_height, resized_width = smart_resize(
+        image.height,
+        image.width,
+        factor=PROCESSOR.image_processor.patch_size
+        * PROCESSOR.image_processor.merge_size,
+        min_pixels=PROCESSOR.image_processor.min_pixels,
+        max_pixels=PROCESSOR.image_processor.max_pixels,
+    )
+
+    return resized_height, resized_width
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local_dir", default="~/data/screenspot")
+    parser.add_argument("--hdfs_dir", default=None)
+
+    args = parser.parse_args()
+
+    data_source = "rootsautomation/ScreenSpot"
+    print(f"Loading the {data_source} dataset from huggingface...", flush=True)
+    dataset = datasets.load_dataset(data_source)
+
+    test_dataset = dataset["test"]
+
+    def make_map_fn(split):
+        def process_fn(example, idx):
+            image = example.pop("image")
+            instruction = example.pop("instruction").strip()
+            bbox = example.pop("bbox")
+            data_type = example.pop("data_type")
+
+            # Get image and resize ratios
+            if isinstance(image, bytes):
+                image = Image.open(io.BytesIO(image))
+            resized_height, resized_width = get_resized_wh(image)
+
+            # Adjust bbox based on resize ratios
+            bbox = [
+                bbox[0] * resized_width,
+                bbox[1] * resized_height,
+                bbox[2] * resized_width,
+                bbox[3] * resized_height,
+            ]
+
+            ground_truth = {
+                "bbox": bbox,
+                "data_type": data_type,
+            }
+
+            data = {
+                "data_source": data_source,
+                "prompt": [
+                    {
+                        "role": "user",
+                        "content": (
+                            "Map the user instruction to the coordinates in the UI image. "
+                            "Think step by step before you answer. The reasoning process MUST BE enclosed within <think> </think> tags. "
+                            "The coordinate x and y MUST BE put in <answer> </answer> tags, separeted by space. "
+                            "<image> Instruction: " + instruction
+                        ),
+                    },
+                ],
+                "images": [image],
+                "ability": "vision",
+                "reward_model": {
+                    "style": "rule",
+                    "ground_truth": ground_truth,
+                },
+                "extra_info": {
+                    "split": split,
+                    "index": idx,
+                    "question": instruction,
+                    "bounding_box": bbox,
+                },
+            }
+            return data
+
+        return process_fn
+
+    test_dataset = test_dataset.map(function=make_map_fn("test"), with_indices=True)
+
+    local_dir = os.path.expanduser(args.local_dir)
+    os.makedirs(local_dir, exist_ok=True)
+
+    test_dataset.to_parquet(os.path.join(local_dir, "test.parquet"))
+
+    if args.hdfs_dir is not None:
+        makedirs(args.hdfs_dir)
+        copy(src=local_dir, dst=args.hdfs_dir)

--- a/orby/data/convert_screenspot.py
+++ b/orby/data/convert_screenspot.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
             }
 
             data = {
-                "data_source": data_source,
+                "data_source": "screenspot",
                 "prompt": [
                     {
                         "role": "user",

--- a/orby/reward/screenspot.py
+++ b/orby/reward/screenspot.py
@@ -1,0 +1,147 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Reward scoring for UI Screenspot task
+"""
+
+import re
+from typing import Dict, List, Tuple, Optional
+
+
+class ScreenspotRewardScorer:
+    """Reward scorer for UI Screenspot task."""
+
+    def __init__(self):
+        super().__init__()
+        self.thinking_pattern = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+        self.answer_pattern = re.compile(r"<answer>(.*?)</answer>", re.DOTALL)
+        self.coordinate_pattern = re.compile(r"(\d*\.?\d+)\s+(\d*\.?\d+)")
+
+    def _extract_coordinates(
+        self, answer_str: str
+    ) -> Tuple[Optional[float], Optional[float]]:
+        """Extract x, y coordinates from answer string.
+
+        Args:
+            answer_str: Answer string in format "x y"
+
+        Returns:
+            Tuple of (x, y) coordinates or (None, None) if not found
+        """
+        match = self.coordinate_pattern.match(answer_str.strip())
+        if not match:
+            return None, None
+        x, y = match.groups()
+        return float(x), float(y)
+
+    def _check_coordinates_in_bbox(
+        self, x: float, y: float, bbox: List[float], tolerance: float = 0.0
+    ) -> bool:
+        """Check if coordinates are within bounding box with tolerance.
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            bbox: Bounding box [x1, y1, x2, y2]
+            tolerance: Coordinate tolerance for matching
+
+        Returns:
+            True if coordinates are within bbox with tolerance
+        """
+        x1, y1, x2, y2 = bbox
+        return (
+            x1 - tolerance <= x <= x2 + tolerance
+            and y1 - tolerance <= y <= y2 + tolerance
+        )
+
+    def score(self, prediction: str, ground_truth: Dict) -> Dict:
+        """Score the prediction against ground truth.
+
+        Args:
+            prediction: Model prediction string
+            ground_truth: Dictionary containing ground truth information
+                - bbox: Bounding box [x1, y1, x2, y2]
+                - data_type: Type of data (optional)
+
+        Returns:
+            Dictionary containing:
+                - score: Overall score (0-1)
+                - details: Dictionary with individual check results
+        """
+        # Check 1: Format validation
+        has_thinking = bool(self.thinking_pattern.search(prediction))
+        answer_match = self.answer_pattern.search(prediction)
+        has_answer = bool(answer_match)
+
+        # Check 2: Coordinate validation
+        pred_answer = answer_match.group(1).strip() if answer_match else ""
+        pred_x, pred_y = self._extract_coordinates(pred_answer)
+
+        bbox = ground_truth.get("bbox")
+        coordinates_correct = False
+        if bbox is not None and pred_x is not None and pred_y is not None:
+            coordinates_correct = self._check_coordinates_in_bbox(pred_x, pred_y, bbox)
+
+        # Calculate overall score
+        format_score = 1.0 if (has_thinking and has_answer) else 0.0
+        coord_score = 1.0 if coordinates_correct else 0.0
+
+        # Weight the scores (can be adjusted based on importance)
+        weights = {"format": 0.2, "coordinates": 0.8}
+
+        overall_score = (
+            weights["format"] * format_score + weights["coordinates"] * coord_score
+        )
+
+        details = {
+            "score": overall_score,
+            "has_thinking": has_thinking,
+            "has_answer": has_answer,
+            "format_score": format_score,
+            "coordinates_predicted": str((pred_x, pred_y))
+            if pred_x is not None and pred_y is not None
+            else "None",
+            "coordinates_ground_truth": str(bbox),
+            "coordinates_score": coord_score,
+        }
+
+        return details
+
+
+def compute_score(prediction: str, ground_truth: Dict) -> Dict:
+    """Compute score for a single prediction.
+
+    Args:
+        prediction: Prediction string
+        ground_truth: Dictionary containing ground truth information
+            - bbox: Bounding box [x1, y1, x2, y2]
+            - data_type: Type of data (optional)
+
+    Returns:
+        Dictionary containing:
+            - score: Overall score (0-1)
+            - details: Dictionary with individual check results
+    """
+    scorer = ScreenspotRewardScorer()
+    result = scorer.score(prediction, ground_truth)
+    return result
+
+
+def reward_func(data_source, solution_str, ground_truth, extra_info=None):
+    if data_source in ["screenspot"]:
+        from orby.reward import screenspot
+
+        return screenspot.compute_score(solution_str, ground_truth)
+    else:
+        raise NotImplementedError

--- a/orby/scripts/eval_screenspot.sh
+++ b/orby/scripts/eval_screenspot.sh
@@ -1,3 +1,5 @@
+set -e
+
 MODEL_PATH=Qwen/Qwen2.5-VL-7B-Instruct
 DATA_PATH=~/data/screenspot
 REWARD_FILE=orby/reward/screenspot.py

--- a/orby/scripts/eval_screenspot.sh
+++ b/orby/scripts/eval_screenspot.sh
@@ -1,0 +1,36 @@
+MODEL_PATH=Qwen/Qwen2.5-VL-7B-Instruct
+DATA_PATH=~/data/screenspot
+REWARD_FILE=orby/reward/screenspot.py
+REWARD_FN=reward_func
+OUTPUT_FILE=test-output-1.parquet
+
+# Convert the dataset to parquet format
+python3 -m orby.data.convert_screenspot
+
+# Generation
+python3 -m orby.trainer.main_generation \
+    trainer.nnodes=1 \
+    trainer.n_gpus_per_node=8 \
+    data.path=$DATA_PATH/test.parquet \
+    data.prompt_key=prompt \
+    data.batch_size=1024 \
+    +data.max_prompt_length=7936 \
+    +data.image_key=images \
+    data.n_samples=1 \
+    data.output_path=$DATA_PATH/$OUTPUT_FILE \
+    model.path=$MODEL_PATH \
+    rollout.temperature=0 \
+    rollout.top_p=1.0 \
+    rollout.prompt_length=7936 \
+    rollout.response_length=256 \
+    rollout.tensor_model_parallel_size=1 \
+    rollout.gpu_memory_utilization=0.9 \
+    rollout.max_num_batched_tokens=65536
+
+# Evaluation
+python3 -m orby.trainer.main_eval \
+    data.path=$DATA_PATH/$OUTPUT_FILE \
+    data.prompt_key=prompt \
+    data.response_key=responses \
+    custom_reward_function.path=$REWARD_FILE \
+    custom_reward_function.name=$REWARD_FN


### PR DESCRIPTION
Tested on interactive instance:

'test_score/screenspot/coordinates_score': 0.3608490566037736,
'test_score/screenspot/format_score': 0.8938679245283019,
'test_score/screenspot/has_answer': 0.9905660377358491,
'test_score/screenspot/has_thinking': 0.9001572327044025,
'test_score/screenspot/score': 0.46745283018867934