### PR TITLE
Use black instead of ruff for formatting

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,10 +25,6 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set ruff --output-format=github
-        run: |
-          sed -i 's/--output-format=full/--output-format=github/' .pre-commit-config.yaml
-          git add .pre-commit-config.yaml
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: "" # Overriding default "--all-files"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,7 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.4"
+  - repo: https://github.com/psf/black
+    rev: 24.2.0
     hooks:
-      - id: ruff
-        args: ["--fix", "--show-fixes", "--output-format=full"]
+      - id: black
+        language_version: python3
         exclude: ^.*\.(ipynb)$
-      - id: ruff-format


### PR DESCRIPTION
Seems running correctly for each commit:

leebird@Gangs-MBP verl % git commit -m "Use black instead of ruff for formatting"
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
black................................................(no files to check)Skipped
[dev 5bc6f83] Use black instead of ruff for formatting
 2 files changed, 4 insertions(+), 9 deletions(-)
