### PR TITLE
Consolidate and automate Screenspot Eval

### DIFF
--- a/orby/mcli/fsdp_sft_qwen2_5_vl_7b.yaml
+++ b/orby/mcli/fsdp_sft_qwen2_5_vl_7b.yaml
@@ -1,4 +1,4 @@
-name: verl-finetune-sft
+name: verl-uitars-sft
 
 image: whatcanyousee/verl:ngc-cu124-vllm0.8.3-sglang0.4.5-mcore0.12.0-te2.2
 integrations:
@@ -9,7 +9,8 @@ integrations:
     ssh_clone: true
 command: |
   export NUM_NODES=4
-  export MODEL_NAME=Qwen/Qwen2.5-VL-7B-Instruct
+  # export MODEL_NAME=ByteDance-Seed/UI-TARS-1.5-7B
+  export MODEL_NAME=/workspace/checkpoints/uitars_7b_40k_sft/
 
   cd /workspace/verl
   sed -i 's|mirrors.tuna.tsinghua.edu.cn|us.archive.ubuntu.com|g' /etc/apt/sources.list
@@ -31,9 +32,15 @@ command: |
   echo "Using interface: $INTERFACE"
   export GLOO_SOCKET_IFNAME=$INTERFACE
   export HF_HUB_ENABLE_HF_TRANSFER=1
+  export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+  export CUDA_LAUNCH_BLOCKING=1
+
+  aws s3 cp --recursive s3://orby-osu-va/verl-checkpoints/uground/uitars_7b_40k_sft/global_step_333/ $MODEL_NAME
+  echo "Downloaded model to: $MODEL_NAME"
+  ls -lt $MODEL_NAME
 
   # Downloads the model
-  python3 -c "import transformers; transformers.pipeline(model='$MODEL_NAME', device='cpu')"
+  # python3 -c "import transformers; transformers.pipeline(model='$MODEL_NAME', device='cpu')"
 
   # Install verl lib: https://verl.readthedocs.io/en/latest/start/install.html
   pip3 install -e .[vllm]
@@ -46,41 +53,48 @@ command: |
   
   # Dynamically list all parquet files in S3 directories
   echo "Discovering parquet files in S3..."
-  TRAIN_FILES=$(aws s3 ls s3://orby-osu-va/Rishu-Uground-test/train/ | grep '\.parquet$' | awk '{print "s3://orby-osu-va/Rishu-Uground-test/train/" $4}' | paste -sd ',' -)
-  VAL_FILES=$(aws s3 ls s3://orby-osu-va/Rishu-Uground-test/test/ | grep '\.parquet$' | awk '{print "s3://orby-osu-va/Rishu-Uground-test/test/" $4}' | paste -sd ',' -)
-  
+  # TRAIN_FILES=$(aws s3 ls s3://orby-osu-va/Rishu-SFT-Dataset/subtask/100k/train/ | grep '\.parquet$' | awk '{print "s3://orby-osu-va/Rishu-SFT-Dataset/subtask/100k/train/" $4}' | head -9 | paste -sd ',' -)
+  # VAL_FILES=$(aws s3 ls s3://orby-osu-va/Rishu-SFT-Dataset/subtask/100k/test/ | grep '\.parquet$' | awk '{print "s3://orby-osu-va/Rishu-SFT-Dataset/subtask/100k/test/" $4}' | head -9 | paste -sd ',' -)
+
+  TRAIN_FILES=s3://orby-osu-va/subtask/verl/experiment_2/train/executor_only_with_response/part-00000-tid-2510824678627585878-9a25a735-1043-4634-8ce5-ba69c841b3ae-959-1-c000.snappy.parquet
+  VAL_FILES=s3://orby-osu-va/subtask/verl/experiment_2/test/executor_only_with_response/part-00000-tid-9197129040143126174-20d9ac95-5f4b-4459-8e6f-15ecd7317e3c-878-1-c000.snappy.parquet
+
   echo "Found train files: $TRAIN_FILES"
   echo "Found val files: $VAL_FILES"
   
   # Run torchrun on each node
   torchrun \
     --nproc_per_node=$NPROC_PER_NODE \
-    --nnodes=4 \
+    --nnodes=$NUM_NODES \
     --node_rank=$NODE_RANK \
     --master_addr=$MASTER_ADDR \
     --master_port=${MASTER_PORT:-29500} \
     -m orby.trainer.fsdp_sft_trainer \
     data.train_batch_size=128 \
-    data.micro_batch_size_per_gpu=4 \
-    data.train_files="[$TRAIN_FILES]" \
-    data.val_files="[$VAL_FILES]" \
+    data.micro_batch_size_per_gpu=2 \
+    data.train_files=$TRAIN_FILES \
+    data.val_files=$VAL_FILES \
     data.prompt_key=prompt \
-    data.response_key=extra_info \
+    data.response_key=response \
+    +data.max_prompt_length=7680 \
+    +data.max_response_length=512 \
     +data.image_key=images \
+    +data.filter_overlong_prompts=False \
+    data.truncation='error' \
+    +data.shuffle=True \
     +processor.use_fast=true \
     +processor.trust_remote_code=true \
     optim.lr=1e-6 \
-    data.response_dict_keys=answer \
     model.partial_pretrain=$MODEL_NAME \
     model.fsdp_config.cpu_offload=true \
     model.enable_gradient_checkpointing=true \
     +model.enable_activation_offload=true \
     model.fsdp_config.offload_params=true \
     +model.fsdp_config.param_offload=true \
-    trainer.default_local_dir=s3://orby-osu-va/Rishu-Uground-test/test-checkpoint \
+    trainer.default_local_dir=s3://orby-osu-va/verl-checkpoints/sft_base/40k_uground_30k_subtask_curriculum_sft_UI-TARS-1.5-7B/ \
     trainer.total_training_steps=null \
-    trainer.project_name=uground-sft \
-    trainer.experiment_name=uground-sft-qwen-2.5-7b \
+    trainer.project_name=uground-subtask-sft-uitars-1.5-7b \
+    trainer.experiment_name=uground-subtask-curriculum-sft-uitars-1.5-7b \
     trainer.logger=[console,wandb] \
     trainer.default_hdfs_dir=null \
     +trainer.val_interval=25 \

--- a/orby/mcli/fsdp_sft_qwen2_5_vl_7b_subtask.yaml
+++ b/orby/mcli/fsdp_sft_qwen2_5_vl_7b_subtask.yaml
@@ -1,4 +1,4 @@
-name: verl-finetune-sft-subtask
+name: verl-sft-uitars-subtask
 
 image: whatcanyousee/verl:ngc-cu124-vllm0.8.3-sglang0.4.5-mcore0.12.0-te2.2
 
@@ -16,12 +16,13 @@ compute:
 
 command: |
   # Set these variables before running the script.
-  export EXPERIMENT_NAME="SET THE EXPERIMENT NAME HERE"
+  export EXPERIMENT_NAME="40k_uground_30k_subtask_curriculum_sft_UI-TARS-1.5-7B"
   export NUM_NODES=8
   export TRAIN_BATCH_SIZE=128
-  export MODEL_NAME=Qwen/Qwen2.5-VL-7B-Instruct
-  export PROJECT_NAME=verl_sft_subtask
-  export S3_CHECKPOINT_DIR=s3://orby-osu-va/verl-checkpoints/subtask_sft/$EXPERIMENT_NAME
+  export MODEL_NAME=/workspace/checkpoints/uitars_7b_40k_sft/
+  export MODEL_PATH=s3://orby-osu-va/verl-checkpoints/uground/uitars_7b_40k_sft/global_step_333/
+  export PROJECT_NAME=verl_sft_uitars
+  export S3_CHECKPOINT_DIR=s3://orby-osu-va/verl-checkpoints/sft_base/$EXPERIMENT_NAME
 
   # Set training environment variables
   export TRAIN_FILES=$HOME/data/subtask_direct_distill/mix/train/combined_with_response.parquet
@@ -51,7 +52,10 @@ command: |
   export CUDA_LAUNCH_BLOCKING=1
 
   # Downloads the model
-  python3 -c "import transformers; transformers.pipeline(model='$MODEL_NAME', device='cpu')"
+  aws s3 cp --recursive $MODEL_PATH $MODEL_NAME
+  echo "Downloaded model to: $MODEL_NAME"
+  ls -lt $MODEL_NAME
+  # python3 -c "import transformers; transformers.pipeline(model='$MODEL_NAME', device='cpu')"
 
   # Install verl lib: https://verl.readthedocs.io/en/latest/start/install.html
   pip3 install -e .[vllm]
@@ -62,8 +66,8 @@ command: |
   # Download merged datasets
   mkdir -p ~/data/subtask_direct_distill/mix/train/
   mkdir -p ~/data/subtask_direct_distill/mix/test/
-  aws s3 cp --no-progress s3://orby-osu-va/subtask/verl/experiment_2/test/executor_reward_model_combined_with_response/part-00000-tid-6116228279497623000-6660e492-d87d-4c87-903b-261c86c79b92-531-1-c000.snappy.parquet $VAL_FILES
-  aws s3 cp --no-progress s3://orby-osu-va/subtask/verl/experiment_2/train/executor_reward_model_combined_with_response/part-00000-tid-3712964276653840281-af2210b2-e910-4427-aa16-9f2a2cfdae0a-844-1-c000.snappy.parquet $TRAIN_FILES
+  aws s3 cp s3://orby-osu-va/subtask/verl/experiment_2/train/executor_only_with_response/part-00000-tid-2510824678627585878-9a25a735-1043-4634-8ce5-ba69c841b3ae-959-1-c000.snappy.parquet $TRAIN_FILES
+  aws s3 cp s3://orby-osu-va/subtask/verl/experiment_2/test/executor_only_with_response/part-00000-tid-9197129040143126174-20d9ac95-5f4b-4459-8e6f-15ecd7317e3c-878-1-c000.snappy.parquet $VAL_FILES
 
   # Run torchrun on each node
   torchrun \
@@ -84,6 +88,7 @@ command: |
     +data.shuffle=True \
     data.prompt_key=prompt \
     data.response_key=response \
+    data.response_dict_keys=null \
     +data.image_key=images \
     +processor.use_fast=true \
     +processor.trust_remote_code=true \

--- a/orby/mcli/ray_eval_screenspot.yaml
+++ b/orby/mcli/ray_eval_screenspot.yaml
@@ -1,0 +1,92 @@
+name: model-merger
+image: whatcanyousee/verl:ngc-cu124-vllm0.8.3-sglang0.4.5-mcore0.12.0-te2.2
+integrations:
+  - integration_type: git_repo
+    git_repo: orby-ai-engineering/verl
+    git_branch: main
+    pip_install: .
+    ssh_clone: true
+command: |
+  cd /workspace/verl
+  sed -i 's|mirrors.tuna.tsinghua.edu.cn|archive.ubuntu.com|g' /etc/apt/sources.list
+  apt update
+  apt install iproute2 -y
+  apt install -y dnsutils
+  apt install -y emacs
+  apt install -y awscli
+  pip install 'urllib3<2'
+  pip install s3fs
+  pip install boto3
+
+  # Define script params
+  export MODEL_NAMES="ByteDance-Seed/UI-TARS-1.5-7B,Qwen/Qwen2.5-VL-7B-Instruct"
+  export DATASET_NAMES="screenspot_subtask,screenspot_v2_subtask,screenspot_pro_subtask"
+
+  # Convert comma-separated strings to arrays
+  IFS=',' read -ra MODEL_ARRAY <<< "$MODEL_NAMES"
+
+  # Check if MODEL_NAMES contains any s3 paths and download them locally
+  NEW_MODEL_NAMES=""
+  for model in "${MODEL_ARRAY[@]}"; do
+    if [[ "$model" == s3://* ]]; then
+      # Extract the model base name from the s3 path
+      model_basename=$(basename "$model")
+      local_dir=~/checkpoints/"$model_basename"
+      mkdir -p "$local_dir"
+      echo "Downloading model from $model to $local_dir"
+      aws s3 sync "$model" "$local_dir"
+      # Use the local directory as the model name for downstream scripts
+      NEW_MODEL_NAMES+="$local_dir,"
+    else
+      NEW_MODEL_NAMES+="$model,"
+    fi
+  done
+  # Remove trailing comma
+  export MODEL_NAMES="${NEW_MODEL_NAMES%,}"
+
+
+  if [ "$NODE_RANK" = "0" ]; then
+
+    # Convert comma-separated strings to arrays
+    IFS=',' read -ra MODEL_ARRAY <<< "$MODEL_NAMES"
+    IFS=',' read -ra DATASET_ARRAY <<< "$DATASET_NAMES"
+
+    # Iterate over each model and dataset combination
+    for model in "${MODEL_ARRAY[@]}"; do
+      for dataset in "${DATASET_ARRAY[@]}"; do
+        echo "Running evaluation for model: $model on dataset: $dataset"
+        
+        # Set the model and dataset for this iteration
+        export MODEL_NAME="$model"
+        export DATASET_NAME="$dataset"
+        
+        # Run the evaluation script with retry logic
+        max_retries=3
+        retry_count=0
+        success=false
+        
+        while [ $retry_count -lt $max_retries ] && [ "$success" = false ]; do
+          echo "Attempt $((retry_count + 1)) of $max_retries for model: $model on dataset: $dataset"
+          
+          if bash ../scripts/eval_screenspot.sh --version "$dataset" --model_name "$model"; then
+            echo "Successfully completed evaluation for model: $model on dataset: $dataset"
+            success=true
+          else
+            retry_count=$((retry_count + 1))
+            if [ $retry_count -lt $max_retries ]; then
+              echo "Evaluation failed for model: $model on dataset: $dataset. Retrying in 30 seconds..."
+              sleep 30
+            else
+              echo "ERROR: Evaluation failed for model: $model on dataset: $dataset after $max_retries attempts"
+              # Do not exit; just continue to the next model+dataset combination
+            fi
+          fi
+        done
+        echo "----------------------------------------"
+      done
+    done
+  fi
+compute:
+  gpus: 8 # Number of GPUs to use
+  cluster: r8z13p2
+  gpu_type: h100_80gb

--- a/orby/mcli/ray_eval_screenspot.yaml
+++ b/orby/mcli/ray_eval_screenspot.yaml
@@ -1,9 +1,9 @@
-name: model-merger
+name: eval-screenspot
 image: whatcanyousee/verl:ngc-cu124-vllm0.8.3-sglang0.4.5-mcore0.12.0-te2.2
 integrations:
   - integration_type: git_repo
     git_repo: orby-ai-engineering/verl
-    git_branch: main
+    git_branch: mpk/uground_eval
     pip_install: .
     ssh_clone: true
 command: |
@@ -17,9 +17,11 @@ command: |
   pip install 'urllib3<2'
   pip install s3fs
   pip install boto3
+  pip install qwen_agent
 
   # Define script params
-  export MODEL_NAMES="ByteDance-Seed/UI-TARS-1.5-7B,Qwen/Qwen2.5-VL-7B-Instruct"
+  # export MODEL_NAMES="ByteDance-Seed/UI-TARS-1.5-7B,Qwen/Qwen2.5-VL-7B-Instruct"
+  export MODEL_NAMES="s3://orby-osu-va/verl-checkpoints/uground/uitars_7b_40k_sft/global_step_333/,s3://orby-osu-va/verl-checkpoints/subtask/verl-sft-uitars-uground-subtask/global_step_469/"
   export DATASET_NAMES="screenspot_subtask,screenspot_v2_subtask,screenspot_pro_subtask"
 
   # Convert comma-separated strings to arrays
@@ -44,7 +46,6 @@ command: |
   # Remove trailing comma
   export MODEL_NAMES="${NEW_MODEL_NAMES%,}"
 
-
   if [ "$NODE_RANK" = "0" ]; then
 
     # Convert comma-separated strings to arrays
@@ -68,7 +69,7 @@ command: |
         while [ $retry_count -lt $max_retries ] && [ "$success" = false ]; do
           echo "Attempt $((retry_count + 1)) of $max_retries for model: $model on dataset: $dataset"
           
-          if bash ../scripts/eval_screenspot.sh --version "$dataset" --model_name "$model"; then
+          if bash /workspace/verl/orby/scripts/eval_screenspot.sh --version "$dataset" --model_name "$model"; then
             echo "Successfully completed evaluation for model: $model on dataset: $dataset"
             success=true
           else

--- a/orby/mcli/ray_train_qwen_2_5_vl_7B_subtask.yaml
+++ b/orby/mcli/ray_train_qwen_2_5_vl_7B_subtask.yaml
@@ -91,6 +91,7 @@ command: |
             data.truncation='error' \
             data.image_key=images \
             data.shuffle=True \
+            +data.max_length=8192 \
             actor_rollout_ref.model.path=$MODEL_NAME \
             actor_rollout_ref.actor.optim.lr=1e-6 \
             actor_rollout_ref.model.use_remove_padding=True \

--- a/orby/scripts/eval_screenspot.sh
+++ b/orby/scripts/eval_screenspot.sh
@@ -221,16 +221,17 @@ fi
 echo "Generation completed successfully. Starting evaluation phase..."
 
 # Evaluation
+export UPLOAD_TO_WANDB=true
+export MODEL_NAME="$MODEL_PATH"
+export DATASET_NAME="$DATASET_VERSION"
+
 python3 -m orby.trainer.main_eval \
     data.path=$DATA_PATH/$OUTPUT_FILE \
     data.prompt_key=prompt \
     data.response_key=responses \
     custom_reward_function.path=$REWARD_FILE \
     custom_reward_function.name=$REWARD_FN \
-    +custom_reward_function.reward_kwargs.prompt_format=$PROMPT_FORMAT \
-    --upload_to_wandb \
-    --model_name "$MODEL_PATH" \
-    --dataset_name "$DATASET_VERSION"
+    +custom_reward_function.reward_kwargs.prompt_format=$PROMPT_FORMAT
 
 if [ $? -ne 0 ]; then
     echo "ERROR: Evaluation phase failed"

--- a/orby/scripts/eval_screenspot.sh
+++ b/orby/scripts/eval_screenspot.sh
@@ -1,12 +1,23 @@
 set -e
 
-# How to run:
+## How to run:
 # bash orby/scripts/eval_screenspot.sh --version screenspot
 # bash orby/scripts/eval_screenspot.sh --version screenspot_v2
 # bash orby/scripts/eval_screenspot.sh --version screenspot_pro
 # bash orby/scripts/eval_screenspot.sh --version screenspot_sft
 # bash orby/scripts/eval_screenspot.sh --version screenspot_v2_sft
 # bash orby/scripts/eval_screenspot.sh --version screenspot_pro_sft
+# bash orby/scripts/eval_screenspot.sh --version screenspot_subtask
+# bash orby/scripts/eval_screenspot.sh --version screenspot_v2_subtask
+# bash orby/scripts/eval_screenspot.sh --version screenspot_pro_subtask
+
+## If you want to run 72B model, you need to run the following command:
+# bash orby/scripts/eval_screenspot.sh --version screenspot --model_size 72
+# bash orby/scripts/eval_screenspot.sh --version screenspot_v2 --model_size 72
+# bash orby/scripts/eval_screenspot.sh --version screenspot_pro --model_size 72
+# bash orby/scripts/eval_screenspot.sh --version screenspot_sft --model_size 72
+# bash orby/scripts/eval_screenspot.sh --version screenspot_v2_sft --model_size 72
+# bash orby/scripts/eval_screenspot.sh --version screenspot_pro_sft --model_size 72
 # bash orby/scripts/eval_screenspot.sh --version screenspot_subtask
 # bash orby/scripts/eval_screenspot.sh --version screenspot_v2_subtask
 # bash orby/scripts/eval_screenspot.sh --version screenspot_pro_subtask

--- a/orby/scripts/eval_screenspot.sh
+++ b/orby/scripts/eval_screenspot.sh
@@ -18,9 +18,9 @@ set -e
 # bash orby/scripts/eval_screenspot.sh --version screenspot_sft --model_size 72
 # bash orby/scripts/eval_screenspot.sh --version screenspot_v2_sft --model_size 72
 # bash orby/scripts/eval_screenspot.sh --version screenspot_pro_sft --model_size 72
-# bash orby/scripts/eval_screenspot.sh --version screenspot_subtask
-# bash orby/scripts/eval_screenspot.sh --version screenspot_v2_subtask
-# bash orby/scripts/eval_screenspot.sh --version screenspot_pro_subtask
+# bash orby/scripts/eval_screenspot.sh --version screenspot_subtask --model_size 72
+# bash orby/scripts/eval_screenspot.sh --version screenspot_v2_subtask --model_size 72
+# bash orby/scripts/eval_screenspot.sh --version screenspot_pro_subtask --model_size 72
 
 # Default values
 DATASET_VERSION="screenspot"

--- a/orby/scripts/eval_screenspot.sh
+++ b/orby/scripts/eval_screenspot.sh
@@ -103,6 +103,7 @@ case $DATASET_VERSION in
         ;;
 esac
 
+# TODO: BUG FIX: 72B model starts the generation but fails after couple of hours with a ray/vllm error.
 if [ $MODEL_SIZE -eq 72 ]; then
     TENSOR_MODEL_PARALLEL_SIZE=8
     BATCH_SIZE=1

--- a/orby/scripts/eval_screenspot.sh
+++ b/orby/scripts/eval_screenspot.sh
@@ -40,10 +40,6 @@ while [[ $# -gt 0 ]]; do
             DATASET_VERSION="$2"
             shift 2
             ;;
-        --prompt_format)
-            PROMPT_FORMAT="$2"
-            shift 2
-            ;;
         --model_size)
             MODEL_SIZE="$2"
             shift 2

--- a/orby/trainer/fsdp_sft_trainer.py
+++ b/orby/trainer/fsdp_sft_trainer.py
@@ -517,6 +517,18 @@ class FSDPSFTTrainer:
                 device=attention_mask.device,
             )
 
+            # Debug: Print detokenized version of all inputs in the batch
+            if self.device_mesh.get_rank() == 0:  # Only print on rank 0 to avoid spam
+                print("=== DEBUG: Detokenized Inputs ===")
+                for i in range(min(3, batch_size)):  # Print first 3 examples
+                    detokenized = self.tokenizer.decode(input_ids[i], skip_special_tokens=False)
+                    print(f"Example {i}:")
+                    print(f"Input IDs shape: {input_ids[i].shape}")
+                    print(f"Detokenized: {detokenized}")
+                    print(f"Assistant token IDs: {assistant_token_ids}")
+                    print("---")
+                print("=== END DEBUG ===")
+
             assistant_len = len(assistant_token_ids)
             prompt_end_position = torch.zeros(
                 batch_size, device=attention_mask.device, dtype=torch.long

--- a/orby/trainer/main_eval.py
+++ b/orby/trainer/main_eval.py
@@ -18,6 +18,7 @@ The input is a parquet file that contains N generated sequences and (optional) t
 """
 
 from collections import defaultdict
+import argparse
 import pprint
 
 import hydra
@@ -43,6 +44,9 @@ def get_custom_reward_fn(config):
         raise FileNotFoundError(f"Reward function file '{file_path}' not found.")
 
     spec = importlib.util.spec_from_file_location("custom_module", file_path)
+    if spec is None:
+        raise RuntimeError(f"Could not create module spec for '{file_path}'")
+    
     module = importlib.util.module_from_spec(spec)
     try:
         spec.loader.exec_module(module)
@@ -50,6 +54,8 @@ def get_custom_reward_fn(config):
         raise RuntimeError(f"Error loading module from '{file_path}'") from e
 
     function_name = reward_fn_config.get("name")
+    if function_name is None:
+        raise ValueError("Reward function name not specified in config")
 
     if not hasattr(module, function_name):
         raise AttributeError(
@@ -84,10 +90,89 @@ def process_item(reward_fn, data_source, response_lst, reward_data):
     return data_source, mean_scores
 
 
+def upload_to_wandb(metric_dict, model_name=None, dataset_name=None):
+    """
+    Upload evaluation results to Weights & Biases as a table.
+    
+    Args:
+        metric_dict: Dictionary containing evaluation metrics
+        model_name: Name of the model being evaluated
+        dataset_name: Name of the dataset being evaluated
+    """
+    try:
+        import wandb
+        
+        # Initialize wandb run
+        wandb.init(
+            project="eval_screenspot",
+            name=f"{model_name}_{dataset_name}" if model_name and dataset_name else "evaluation",
+            config={
+                "model_name": model_name,
+                "dataset_name": dataset_name,
+                "evaluation_type": "screenspot"
+            }
+        )
+        
+        # Create a table from the metric dictionary
+        # Convert the nested dictionary structure to a flat table
+        table_data = []
+        
+        for metric_key, metric_value in metric_dict.items():
+            # Parse the metric key to extract components
+            # Format: test_score/{data_source}/{metric_name}
+            parts = metric_key.split('/')
+            if len(parts) >= 3:
+                data_source = parts[1]
+                metric_name = '/'.join(parts[2:])
+                
+                table_data.append({
+                    "data_source": data_source,
+                    "metric_name": metric_name,
+                    "metric_value": float(metric_value),
+                    "full_metric_key": metric_key
+                })
+        
+        if table_data:
+            # Create wandb table
+            table = wandb.Table(columns=["data_source", "metric_name", "metric_value", "full_metric_key"])
+            for row in table_data:
+                table.add_data(row["data_source"], row["metric_name"], row["metric_value"], row["full_metric_key"])
+            
+            # Log the table
+            wandb.log({"evaluation_results": table})
+            
+            # Also log individual metrics for easier tracking
+            for metric_key, metric_value in metric_dict.items():
+                wandb.log({metric_key: float(metric_value)})
+            
+            print(f"Successfully uploaded {len(table_data)} metrics to wandb")
+        else:
+            print("Warning: No metrics to upload to wandb")
+            
+        wandb.finish()
+        
+    except ImportError:
+        print("Warning: wandb not installed. Skipping wandb upload.")
+    except Exception as e:
+        print(f"Error uploading to wandb: {e}")
+
+
 @hydra.main(
     config_path="../../verl/trainer/config", config_name="evaluation", version_base=None
 )
 def main(config):
+    # Parse additional command line arguments
+    parser = argparse.ArgumentParser(description="Evaluation script with wandb upload option")
+    parser.add_argument("--upload_to_wandb", action="store_true", 
+                       help="Upload results to Weights & Biases")
+    parser.add_argument("--model_name", type=str, default=None,
+                       help="Name of the model being evaluated")
+    parser.add_argument("--dataset_name", type=str, default=None,
+                       help="Name of the dataset being evaluated")
+    
+    # Parse known args to avoid conflicts with hydra
+    args, unknown = parser.parse_known_args()
+    
     local_path = copy_to_local(config.data.path)
     dataset = pd.read_parquet(
         local_path,
@@ -137,6 +222,10 @@ def main(config):
             metric_dict[f"test_score/{data_source}/{k}"] = v
 
     pprint.pprint(metric_dict)
+    
+    # Upload to wandb if requested
+    if args.upload_to_wandb:
+        upload_to_wandb(metric_dict, args.model_name, args.dataset_name)
 
 
 if __name__ == "__main__":

--- a/verl/trainer/config/sft_trainer.yaml
+++ b/verl/trainer/config/sft_trainer.yaml
@@ -14,6 +14,7 @@ data:
     enable: false  # Set to true to use multi-turn dataset
     messages_key: messages  # Key for messages list in multi-turn mode
   max_length: 1024
+  max_prompt_length: 8192
   truncation: error
   balance_dp_token: False
   chat_template: null


### PR DESCRIPTION
### What does this PR do?
This PR adds a new script to submit screenspot eval jobs on mosaic clusters. You specify a list of models and datasets to do evaluation. The script automatically launches evaluation for every model + dataset combination. This PR also introduces a change to publish the eval results on WANDB for tracking and persistence. 

### Usage Example
In the yaml config file, provide models and dataset names as a comma-separated string. The model names should be provided as s3 paths. Model download from s3 buckets is handled in the script. Follow the example below
```
export MODEL_NAMES="s3://orby-osu-va/verl-checkpoints/uground/uitars_7b_40k_sft/global_step_333/,s3://orby-osu-va/verl-checkpoints/subtask/verl-sft-uitars-uground-subtask/global_step_469/"
export DATASET_NAMES="screenspot_subtask,screenspot_v2_subtask,screenspot_pro_subtask"
```