### PR TITLE
Cheng/edit interleave pipe

### DIFF
--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -42,7 +42,7 @@ command: |
   export INITIAL_SFT_TRAIN_FILES=$LOCAL_DATA_DIR/sft_train.parquet
 
   # Change this to the shared validation files for all steps.
-  export SHARED_VAL_FILES=$LOCAL_DATA_DIR/sft_test.parquet
+  export SHARED_VAL_FILES=$LOCAL_DATA_DIR/test.parquet
 
   # Set batch sizes based on the number of GPUs. Note max sft micro batch size per GPU is 4.
   # Rollout batch size 1024 is tested, larger rollout batch size may be feasible, but may cause OOM

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -10,7 +10,7 @@ integrations:
     ssh_clone: true
 
 compute:
-  gpus: 16 # Number of GPUs to use
+  gpus: 64 # Number of GPUs to use
   cluster: r8z13p2
   gpu_type: h100_80gb
 
@@ -45,10 +45,10 @@ command: |
   # Set batch sizes based on the number of GPUs. Note max sft micro batch size per GPU is 4.
   # Rollout batch size 1024 is tested, larger rollout batch size may be feasible, but may cause OOM
   # on the main node as it needs to load the entire rollout batch into memory.
-  export NUM_NODES=2
-  export SFT_MICRO_BATCH_SIZE_PER_GPU=4
-  export SFT_TRAIN_BATCH_SIZE=64
-  export GRPO_MICRO_BATCH_SIZE_PER_GPU=4
+  export NUM_NODES=8
+  export SFT_MICRO_BATCH_SIZE_PER_GPU=2
+  export SFT_TRAIN_BATCH_SIZE=128
+  export GRPO_MICRO_BATCH_SIZE_PER_GPU=1
   export GRPO_TRAIN_BATCH_SIZE=64
   export ROLLOUT_BATCH_SIZE=1024
 

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -19,6 +19,8 @@ command: |
   export EXPERIMENT_NAME="SET EXPERIMENT NAME"
   export PROJECT_NAME=verl_interleaved
   export MODEL_NAME=Qwen/Qwen2.5-VL-7B-Instruct
+  # Set this if you want to skip the initial SFT step and start from a checkpoint
+  export BASE_SFT_CHECKPOINT=
 
   # Set the number of steps to interleave. Make sure the data directory contains the data for all steps.
   export INTERLEAVED_STEP_NUM=1
@@ -99,9 +101,6 @@ command: |
   export GLOO_SOCKET_IFNAME=$INTERFACE
   export HF_HUB_ENABLE_HF_TRANSFER=1
   export CUDA_LAUNCH_BLOCKING=1
-
-  # Download model
-  python3 -c "import transformers; transformers.pipeline(model='$MODEL_NAME', device='cpu')"
 
   # Install verl lib: https://verl.readthedocs.io/en/latest/start/install.html
   pip3 install -e .[vllm]

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -79,7 +79,7 @@ command: |
   export REWARD_SCORE_COLUMN="reward_score"
 
   # Set rollout parameters
-  export ROLLOUT_OUTPUT_DIR=s3://orby-llm/interleaved/rollout/$EXPERIMENT_NAME
+  export S3_ROLLOUT_OUTPUT_DIR=s3://orby-llm/interleaved/rollout/$EXPERIMENT_NAME
   export N_SAMPLES=4
   export TEMPERATURE=0.7
 

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -65,6 +65,10 @@ command: |
   export GRPO_LR=1e-6
   export GENERATED_DATA_RESPONSE_KEY=predictions
 
+  # Set eval parameters
+  export EVAL_REWARD_FN=eval_reward_func
+  export EVAL_OUTPUT_FILE=$LOCAL_DATA_DIR/tmp_eval_output.parquet
+
   # Set difficulty filter parameters
   export MEDIUM_DIFFICULTY_FILTER_BOUND_STR="[0.51, 0.9]"
   export HARD_DIFFICULTY_FILTER_BOUND_STR="[0.09, 0.5]"

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -72,8 +72,10 @@ command: |
   export EVAL_OUTPUT_FILE=$LOCAL_DATA_DIR/tmp_eval_output.parquet
 
   # Set difficulty filter parameters
-  export MEDIUM_DIFFICULTY_FILTER_BOUND_STR="[0.51,0.9]"
-  export HARD_DIFFICULTY_FILTER_BOUND_STR="[0.09,0.5]"
+  export MEDIUM_DIFFICULTY_FILTER_UPPER_BOUND=0.9
+  export MEDIUM_DIFFICULTY_FILTER_LOWER_BOUND=0.51
+  export HARD_DIFFICULTY_FILTER_UPPER_BOUND=0.5
+  export HARD_DIFFICULTY_FILTER_LOWER_BOUND=0.09
   export REWARD_SCORE_COLUMN="reward_score"
 
   # Set rollout parameters

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -28,6 +28,7 @@ command: |
   # Set data paths
   export LOCAL_DATA_DIR=$HOME/data
   export LOCAL_MODEL_DIR=$HOME/model
+  export LOCAL_EVAL_DIR=$HOME/eval
   export S3_CHECKPOINT_DIR=s3://orby-llm/interleaved/checkpoints/$EXPERIMENT_NAME
 
   # This should contain the training data for all steps. For example,
@@ -70,6 +71,8 @@ command: |
   # Set eval parameters
   export EVAL_REWARD_FN=eval_reward_func
   export EVAL_OUTPUT_FILE=$LOCAL_DATA_DIR/tmp_eval_output.parquet
+  export LOCAL_EVAL_RESULT_FILE=$LOCAL_EVAL_DIR/results.parquet
+  export S3_EVAL_RESULT_FILE=s3://orby-llm/interleaved/eval/$EXPERIMENT_NAME/results.parquet
 
   # Set difficulty filter parameters
   export MEDIUM_DIFFICULTY_FILTER_UPPER_BOUND=0.9

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -72,8 +72,8 @@ command: |
   export EVAL_OUTPUT_FILE=$LOCAL_DATA_DIR/tmp_eval_output.parquet
 
   # Set difficulty filter parameters
-  export MEDIUM_DIFFICULTY_FILTER_BOUND_STR="[0.51, 0.9]"
-  export HARD_DIFFICULTY_FILTER_BOUND_STR="[0.09, 0.5]"
+  export MEDIUM_DIFFICULTY_FILTER_BOUND_STR="[0.51,0.9]"
+  export HARD_DIFFICULTY_FILTER_BOUND_STR="[0.09,0.5]"
   export REWARD_SCORE_COLUMN="reward_score"
 
   # Set rollout parameters

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -72,7 +72,8 @@ command: |
   export EVAL_REWARD_FN=eval_reward_func
   export EVAL_OUTPUT_FILE=$LOCAL_DATA_DIR/tmp_eval_output.parquet
   export LOCAL_EVAL_RESULT_FILE=$LOCAL_EVAL_DIR/results.parquet
-  export S3_EVAL_RESULT_FILE=s3://orby-llm/interleaved/eval/$EXPERIMENT_NAME/results.parquet
+  export S3_EVAL_RESULT_DIR=s3://orby-llm/interleaved/eval/$EXPERIMENT_NAME
+  export S3_EVAL_RESULT_FILE=$S3_EVAL_RESULT_DIR/results.parquet
 
   # Set difficulty filter parameters
   export MEDIUM_DIFFICULTY_FILTER_UPPER_BOUND=0.9

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -105,4 +105,5 @@ command: |
   aws s3 cp --no-progress --recursive $INTERLEAVED_DATA_DIR $LOCAL_DATA_DIR
 
   # Run interleaved pipeline
+  echo "TOP LEVEL - Now starting the interleaved training pipeline at orby/scripts/interleaved_pipeline.sh"
   bash orby/scripts/interleaved_pipeline.sh

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -86,6 +86,7 @@ command: |
   pip install s3fs
   pip install sgl-kernel
   pip install boto3
+  pip install parquet-tools
 
   # Set environment variables
   export HYDRA_FULL_ERROR=1

--- a/orby/scripts/eval_qwen_2_5_vl_subtask.sh
+++ b/orby/scripts/eval_qwen_2_5_vl_subtask.sh
@@ -15,6 +15,7 @@ python3 -m orby.trainer.main_generation \
     data.prompt_key=prompt \
     data.batch_size=1024 \
     +data.max_prompt_length=7680 \
+    +data.filter_overlong_prompts=false \
     data.n_samples=1 \
     data.output_path=$OUTPUT_FILE \
     model.path=$MODEL_PATH \

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -54,7 +54,7 @@ generate_rollout_data() {
         --runtime-env=verl/trainer/runtime_env.yaml \
         --no-wait \
         -- \
-        python3 -u -m orby.trainer.main_generation \
+        python3 -m orby.trainer.main_generation \
             trainer.nnodes=$NUM_NODES \
             trainer.n_gpus_per_node=8 \
             data.path=$train_files \

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -217,6 +217,7 @@ eval_step() {
         data.prompt_key=prompt \
         data.batch_size=1024 \
         +data.max_prompt_length=7680 \
+        +data.filter_overlong_prompts=false \
         data.n_samples=1 \
         data.output_path=$EVAL_OUTPUT_FILE \
         model.path=$model_path \
@@ -273,8 +274,8 @@ filter_step() {
         data.path=$input_parquet_with_rollout \
         data.medium_difficulty_output_path=$medium_difficulty_train_files \
         data.hard_difficulty_output_path=$hard_difficulty_train_files \
-        data.medium_difficulty_filter_bound=$medium_difficulty_filter_bound_str \
-        data.hard_difficulty_filter_bound=$hard_difficulty_filter_bound_str \
+        data.medium_difficulty_filter_bound="${medium_difficulty_filter_bound_str}" \
+        data.hard_difficulty_filter_bound="${hard_difficulty_filter_bound_str}" \
         data.balance_should_end=true \
         data.should_end_column="reward_model.ground_truth.should_end" \
         data.reward_score_column=$REWARD_SCORE_COLUMN

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -371,6 +371,8 @@ for i in $(seq 0 $((INTERLEAVED_STEP_NUM - 1))); do
     # PER_STEP_VAL_FILES=$LOCAL_DATA_DIR/$i/test.parquet
     LOCAL_OUTPUT_PARQUET=$LOCAL_DATA_DIR/$i/train_rollout.parquet
     ROLLOUT_OUTPUT_PARQUET=$ROLLOUT_OUTPUT_DIR/$i/train_rollout.parquet
+    PER_STEP_GRPO_TRAIN_FILES=$LOCAL_DATA_DIR/$i/grpo_train.parquet
+    PER_STEP_SFT_TRAIN_FILES=$LOCAL_DATA_DIR/$i/sft_train.parquet
 
     # Start ray cluster and wait for all nodes
     bash orby/scripts/run_ray.sh $NUM_NODES

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail # Exit on any error or undefined variable
 
 # Clean up synchronization flags on in case of resume
 if [ "$NODE_RANK" = "0" ]; then

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -321,7 +321,7 @@ for i in $(seq 0 $((INTERLEAVED_STEP_NUM - 1))); do
         aws s3 cp --no-progress $LOCAL_OUTPUT_PARQUET $ROLLOUT_OUTPUT_PARQUET
 
         # 2) Filtering step
-        echo "TOP LEVEL - Step 1.$i.1: submitting filtering job on node 0 ========================================"
+        echo "TOP LEVEL - Step 1.$i.1: filter by difficulty on node 0 ============================================"
         filter_step $LOCAL_OUTPUT_PARQUET \
         $PER_STEP_GRPO_TRAIN_FILES \
         $PER_STEP_SFT_TRAIN_FILES \

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail # Exit on any error or undefined variable
 
+# Clean up synchronization flags on in case of resume
+if [ "$NODE_RANK" = "0" ]; then
+    aws s3 rm --recursive "$S3_CHECKPOINT_DIR/sync_flags/" >/dev/null 2>&1 || true
+fi
+
 # Create all directories
 mkdir -p $LOCAL_DATA_DIR
 mkdir -p $LOCAL_MODEL_DIR

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -538,9 +538,8 @@ for i in $(seq 0 $((INTERLEAVED_STEP_NUM - 1))); do
         sleep 300
     fi
 
-    # Download the merged checkpoint
-    export LOCAL_GRPO_CHECKPOINT=$LOCAL_MODEL_DIR/grpo_${i}/$STEP_DIR
     # Download the GRPO checkpoint on all nodes
+    export LOCAL_GRPO_CHECKPOINT=$LOCAL_MODEL_DIR/grpo_${i}/$STEP_DIR
     aws s3 cp --no-progress --recursive $MAX_STEPS_CHECKPOINT_HF $LOCAL_GRPO_CHECKPOINT
 
     # Evaluation

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -513,9 +513,14 @@ done
 
 # Final report
 echo "TOP LEVEL - Step 2: report results ================================================================="
+# Upload the evaluation results to S3 on node 0
+if [ "$NODE_RANK" = "0" ]; then
+    aws s3 cp --no-progress $LOCAL_EVAL_RESULT_FILE $S3_EVAL_RESULT_FILE
+fi
+
 echo "All training rounds are done."
 echo "All checkpoints are available at: $S3_CHECKPOINT_DIR"
 echo "All rollout data are available at: $S3_ROLLOUT_OUTPUT_DIR"
-echo "All evaluation results are available at: $S3_EVAL_OUTPUT_DIR"
+echo "All evaluation results are available at: $S3_EVAL_RESULT_DIR"
 
 echo "TOP LEVEL - ALL DONE ==============================================================================="

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -492,8 +492,8 @@ for i in $(seq 0 $((INTERLEAVED_STEP_NUM - 1))); do
             # Upload dataset to S3; only make one call on node 0
             aws s3 cp --no-progress $LOCAL_PER_STEP_GRPO_TRAIN_FILES $S3_PER_STEP_GRPO_TRAIN_FILES
             aws s3 cp --no-progress $LOCAL_PER_STEP_SFT_TRAIN_FILES $S3_PER_STEP_SFT_TRAIN_FILES
-            # Note: No synchronization needed here - Ray manages the distributed execution
         fi
+        # Note: No synchronization needed here - Ray manages the distributed execution
     fi
 
     # 3) Run GRPO step
@@ -512,11 +512,13 @@ for i in $(seq 0 $((INTERLEAVED_STEP_NUM - 1))); do
                 $S3_GRPO_CHECKPOINT_DIR \
                 $GRPO_LR \
                 $GRPO_MICRO_BATCH_SIZE_PER_GPU
-
-            # Stop ray cluster
-            ray stop
-            # Note: No synchronization needed here - Ray manages the distributed execution
         fi
+        # Note: No synchronization needed here - Ray manages the distributed execution
+    fi
+
+    # Stop ray cluster
+    if [ "$NODE_RANK" = "0" ]; then
+        ray stop
     fi
 
     # Find the GRPO checkpoint with maximum steps

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -409,9 +409,8 @@ echo "TOP LEVEL - Collected initial SFT checkpoint: $S3_INIT_SFT_CHECKPOINT"
 # Copy the initial SFT checkpoint with maximum steps
 export STEP_DIR=$(extract_step_from_checkpoint_dir $S3_INIT_SFT_CHECKPOINT)
 export LOCAL_SFT_CHECKPOINT=$LOCAL_MODEL_DIR/initial_sft/$STEP_DIR
-# Download the SFT checkpoint only to node 0
-run_on_node0_and_sync "initial_checkpoint_download" \
-    aws s3 cp --no-progress --recursive $S3_INIT_SFT_CHECKPOINT $LOCAL_SFT_CHECKPOINT
+# Download the SFT checkpoint on all nodes
+aws s3 cp --no-progress --recursive $S3_INIT_SFT_CHECKPOINT $LOCAL_SFT_CHECKPOINT
 
 # Evaluation
 echo "TOP LEVEL - Step 0.1: evaluating initial SFT checkpoint ============================================"

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -341,7 +341,7 @@ else
     echo "TOP LEVEL - Step 0.0: downloading initial SFT checkpoint ==========================================="
     export STEP_DIR=$(extract_step_from_checkpoint_dir $BASE_SFT_CHECKPOINT)
     export MAX_STEPS_CHECKPOINT=$S3_INITIAL_SFT_CHECKPOINT_DIR/$STEP_DIR
-    aws s3 cp --no-progress $BASE_SFT_CHECKPOINT $MAX_STEPS_CHECKPOINT
+    aws s3 cp --no-progress --recursive $BASE_SFT_CHECKPOINT $MAX_STEPS_CHECKPOINT
 fi
 
 echo "TOP LEVEL - Collected initial SFT checkpoint: $MAX_STEPS_CHECKPOINT"

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -524,7 +524,7 @@ for i in $(seq 0 $((INTERLEAVED_STEP_NUM - 1))); do
     # Find the GRPO checkpoint with maximum steps
     export MAX_STEPS_CHECKPOINT=$(find_max_step_checkpoint "$S3_GRPO_CHECKPOINT_DIR")
 
-    echo "TOP LEVEL - Step 1.$i.3: merging GRPO checkpoint on node 0 ========================================="
+    echo "TOP LEVEL - Step 1.$i.3: merging GRPO checkpoint on node 0 ========================================"
     run_on_node0_and_sync "checkpoint_merge_$i" \
         merge_checkpoint $MAX_STEPS_CHECKPOINT
 

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail # Exit on any error or undefined variable
+set -x # Print each command before executing it
 
 # Function to find checkpoint with maximum steps from S3 directory
 find_max_step_checkpoint() {

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -178,7 +178,7 @@ grpo_step() {
         actor_rollout_ref.model.enable_gradient_checkpointing=True \
         actor_rollout_ref.actor.fsdp_config.param_offload=True \
         actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
-        actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=16 \
+        actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
         actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=8192 \
         actor_rollout_ref.rollout.tensor_model_parallel_size=4 \
         actor_rollout_ref.rollout.name=vllm \
@@ -189,7 +189,7 @@ grpo_step() {
         actor_rollout_ref.rollout.n=4 \
         actor_rollout_ref.rollout.max_model_len=8192 \
         +actor_rollout_ref.rollout.limit_images=3 \
-        actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=16 \
+        actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
         actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=8192 \
         actor_rollout_ref.ref.fsdp_config.param_offload=True \
         algorithm.use_kl_in_reward=False \

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -589,11 +589,10 @@ echo "TOP LEVEL - Step 2: report results =======================================
 if [ "$NODE_RANK" = "0" ]; then
     aws s3 cp --no-progress $LOCAL_EVAL_RESULT_FILE $S3_EVAL_RESULT_FILE
     # Clean up synchronization flags
+    sleep 60 # Wait to make sure worker nodes sees the final eval complete flag
     echo "TOP LEVEL - Cleaning up synchronization flags..."
     aws s3 rm --recursive "$S3_CHECKPOINT_DIR/sync_flags/" >/dev/null 2>&1 || true
-    signal_step_complete "final_report"
 fi    
-wait_for_step_complete "final_report"
 
 echo "All training rounds are done."
 echo "All checkpoints are available at: $S3_CHECKPOINT_DIR"
@@ -601,3 +600,5 @@ echo "All rollout data are available at: $S3_ROLLOUT_OUTPUT_DIR"
 echo "All evaluation results are available at: $S3_EVAL_RESULT_DIR"
 
 echo "TOP LEVEL - ALL DONE ==============================================================================="
+
+exit 0

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -247,8 +247,10 @@ filter_step() {
     local input_parquet_with_rollout="$1"
     local medium_difficulty_train_files="$2"
     local hard_difficulty_train_files="$3"
-    local medium_difficulty_filter_bound_str="$4"
-    local hard_difficulty_filter_bound_str="$5"
+    local medium_difficulty_filter_upper_bound="$4"
+    local medium_difficulty_filter_lower_bound="$5"
+    local hard_difficulty_filter_upper_bound="$6"
+    local hard_difficulty_filter_lower_bound="$7"
 
     echo "TOP LEVEL - Step 1.$i.1.0: generating scores ======================================================="
 
@@ -274,8 +276,10 @@ filter_step() {
         data.path=$input_parquet_with_rollout \
         data.medium_difficulty_output_path=$medium_difficulty_train_files \
         data.hard_difficulty_output_path=$hard_difficulty_train_files \
-        data.medium_difficulty_filter_bound="'${medium_difficulty_filter_bound_str}'" \
-        data.hard_difficulty_filter_bound="'${hard_difficulty_filter_bound_str}'" \
+        data.medium_difficulty_filter_upper_bound=$medium_difficulty_filter_upper_bound \
+        data.medium_difficulty_filter_lower_bound=$medium_difficulty_filter_lower_bound \
+        data.hard_difficulty_filter_upper_bound=$hard_difficulty_filter_upper_bound \
+        data.hard_difficulty_filter_lower_bound=$hard_difficulty_filter_lower_bound \
         data.balance_should_end=true \
         data.should_end_column="reward_model.ground_truth.should_end" \
         data.reward_score_column=$REWARD_SCORE_COLUMN
@@ -395,8 +399,10 @@ for i in $(seq 0 $((INTERLEAVED_STEP_NUM - 1))); do
         filter_step $LOCAL_OUTPUT_PARQUET \
         $PER_STEP_GRPO_TRAIN_FILES \
         $PER_STEP_SFT_TRAIN_FILES \
-        $MEDIUM_DIFFICULTY_FILTER_BOUND_STR \
-        $HARD_DIFFICULTY_FILTER_BOUND_STR
+        $MEDIUM_DIFFICULTY_FILTER_UPPER_BOUND \
+        $MEDIUM_DIFFICULTY_FILTER_LOWER_BOUND \
+        $HARD_DIFFICULTY_FILTER_UPPER_BOUND \
+        $HARD_DIFFICULTY_FILTER_LOWER_BOUND
 
         # 3) Run GRPO step
         echo "TOP LEVEL - Step 1.$i.2: submitting GRPO job on node 0 ============================================="

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -274,8 +274,8 @@ filter_step() {
         data.path=$input_parquet_with_rollout \
         data.medium_difficulty_output_path=$medium_difficulty_train_files \
         data.hard_difficulty_output_path=$hard_difficulty_train_files \
-        data.medium_difficulty_filter_bound="${medium_difficulty_filter_bound_str}" \
-        data.hard_difficulty_filter_bound="${hard_difficulty_filter_bound_str}" \
+        data.medium_difficulty_filter_bound="'${medium_difficulty_filter_bound_str}'" \
+        data.hard_difficulty_filter_bound="'${hard_difficulty_filter_bound_str}'" \
         data.balance_should_end=true \
         data.should_end_column="reward_model.ground_truth.should_end" \
         data.reward_score_column=$REWARD_SCORE_COLUMN

--- a/orby/trainer/config/reward_filter.yaml
+++ b/orby/trainer/config/reward_filter.yaml
@@ -2,8 +2,10 @@ data:
   path: /tmp/input_with_rollout.parquet
   medium_difficulty_output_path: /tmp/medium_difficulty_train.parquet
   hard_difficulty_output_path: /tmp/hard_difficulty_train.parquet
-  medium_difficulty_filter_bound: "[0.51,0.9]"
-  hard_difficulty_filter_bound: "[0.09,0.5]"
+  medium_difficulty_filter_upper_bound: 0.9
+  medium_difficulty_filter_lower_bound: 0.51
+  hard_difficulty_filter_upper_bound: 0.5
+  hard_difficulty_filter_lower_bound: 0.09
   balance_should_end: true
   should_end_column: "reward_model.ground_truth.should_end"
   reward_score_column: "reward_score"

--- a/orby/trainer/config/reward_filter.yaml
+++ b/orby/trainer/config/reward_filter.yaml
@@ -2,8 +2,8 @@ data:
   path: /tmp/input_with_rollout.parquet
   medium_difficulty_output_path: /tmp/medium_difficulty_train.parquet
   hard_difficulty_output_path: /tmp/hard_difficulty_train.parquet
-  medium_difficulty_filter_bound: "[0.51, 0.9]"
-  hard_difficulty_filter_bound: "[0.09, 0.5]"
+  medium_difficulty_filter_bound: "[0.51,0.9]"
+  hard_difficulty_filter_bound: "[0.09,0.5]"
   balance_should_end: true
   should_end_column: "reward_model.ground_truth.should_end"
   reward_score_column: "reward_score"

--- a/orby/trainer/config/reward_filter.yaml
+++ b/orby/trainer/config/reward_filter.yaml
@@ -2,8 +2,8 @@ data:
   path: /tmp/input_with_rollout.parquet
   medium_difficulty_output_path: /tmp/medium_difficulty_train.parquet
   hard_difficulty_output_path: /tmp/hard_difficulty_train.parquet
-  medium_difficulty_filter_bound: [0.51, 0.9]
-  hard_difficulty_filter_bound: [0.09, 0.5]
+  medium_difficulty_filter_bound: "[0.51, 0.9]"
+  hard_difficulty_filter_bound: "[0.09, 0.5]"
   balance_should_end: true
   should_end_column: "reward_model.ground_truth.should_end"
   reward_score_column: "reward_score"

--- a/orby/trainer/main_reward_filter.py
+++ b/orby/trainer/main_reward_filter.py
@@ -7,21 +7,6 @@ import pyarrow.parquet as pq
 from verl.utils.fs import copy_to_local
 
 
-def parse_filter_bounds(bounds_str):
-    """Parse filter bounds string like '[0.51, 0.9]' into tuple."""
-    # If it's already a list/tuple, return it as tuple
-    if isinstance(bounds_str, (list, tuple)):
-        return tuple(bounds_str)
-
-    # If it's a string, try to parse it
-    if isinstance(bounds_str, str):
-        bounds = ast.literal_eval(bounds_str)
-        return tuple(bounds)
-
-    # If it is a ListConfig
-    return (bounds_str[0], bounds_str[1])
-
-
 def extract_should_end_values(df, should_end_column):
     """Extract should_end values from nested dictionary structure."""
     should_end_values = []
@@ -173,11 +158,17 @@ def filter_parquet_chunks(
 def main(config):
     # Get local copy of input file
     local_input_path = copy_to_local(config.data.path)
-    
+
     # Parse filter bounds
-    medium_bounds = parse_filter_bounds(config.data.medium_difficulty_filter_bound)
-    hard_bounds = parse_filter_bounds(config.data.hard_difficulty_filter_bound)
-    
+    medium_bounds = (
+        config.data.medium_difficulty_filter_lower_bound,
+        config.data.medium_difficulty_filter_upper_bound
+    )
+    hard_bounds = (
+        config.data.hard_difficulty_filter_lower_bound,
+        config.data.hard_difficulty_filter_upper_bound
+    )
+
     # Get balancing configuration
     balance_should_end = config.data.get("balance_should_end", True)
     should_end_column = config.data.get("should_end_column", "reward_model.ground_truth.should_end")


### PR DESCRIPTION
This PR debugs the filtering and interleave training pipeline by

**Bug fixes**
- Changing log_prob_micro_batch_size of GRPO to 1 so that small GRPO batchsize can be used with large GPU counts;
- Changing ways of specifying filtering difficulty upper and lower bounds so it is passed correctly among yaml / bash / hydra config / python code;
- Change filtering data upload & download so that worker nodes can receive dataset;
- Other miscellaneous bug fixes.

**Improvements**
- Adding more informative print statement in pipeline for better debugging / tracking experience;
- Evaluate and store evaluation result for each step of the pipeline;
- Ability to resume experiment from initial SFT / rollout & filtering / GRPO / SFT.
- etc.

Notes:
- This pipeline has been tested with debug dataset: https://console.mosaicml.com/orbyai/runs/verl-interleaved-FELkzR. Tests with training data is still needed.
- When viewing log on mosaic cluster, please use mcli log **-f**. The `-f` is necessary for print statements / error messages to be correctly displayed; otherwise some processes might fail without error.
- The resume function will only search for existence of checkpoints in the s3 storage. If the pipeline broke during a training session, a checkpoint not fully trained might still have been saved and used by mistake after resume. In this case a manual reset (delete folder on s3) is needed.