### PR TITLE
Support multitask GRPO training

### DIFF
--- a/orby/data/merge_multitask_parquet.py
+++ b/orby/data/merge_multitask_parquet.py
@@ -1,0 +1,50 @@
+import datasets
+from datasets import Sequence, Image
+
+
+def fix_dataset_format_for_merge(dataset):
+    if "images" in dataset.features:
+        # Check if images are in Dataset 2 format (list of dicts with bytes/path)
+        # Dataset subtask_direct_distill format: [{'bytes': binary, 'path': int32}]
+        # Dataset uground,os_atlas format: Sequence(feature=Image(mode=None, decode=True))
+        if type(dataset.features["images"]) == list:
+            print(
+                "Converting image format from [{'bytes': binary, 'path': int32}] to Sequence[Image]"
+            )
+            # Cast the images column to the new Sequence type
+            dataset = dataset.cast_column(
+                "images", Sequence(feature=Image(decode=True), length=-1)
+            )
+
+    # In all datasets, the response field is a list of dicts with role and content keys
+    # The order of keys is "role" and "content" in subtask_direct_distill dataset, and "content" and "role" in uground,os_atlas dataset
+    # This leads to a mismatch in the response schema between the two datasets, which results in a failure to concatenate the two datasets
+    # Change response message key order for subtask_direct_distill dataset
+    if (
+        "data_source" in dataset.features
+        and dataset["data_source"][0] == "subtask_direct_distill"
+    ):
+        print("Standardizing response message key order")
+
+        # Explicitly cast the response column to ensure schema compatibility
+        response_features = [
+            {"content": datasets.Value("string"), "role": datasets.Value("string")}
+        ]
+
+        # Create new features with the correct order
+        new_features = dataset.features.copy()
+        new_features["response"] = response_features
+
+        # Cast the dataset to the new schema
+        dataset = dataset.cast(new_features)
+
+
+parquet_files = ["~/data/uground.parquet", "~/data/subtask.parquet"]
+dataframes = []
+for parquet_file in parquet_files:
+    dataframe = datasets.load_dataset("parquet", data_files=parquet_file)
+    dataframe = fix_dataset_format_for_merge(dataframe)
+    dataframes.append(dataframe)
+
+dataframe: datasets.Dataset = datasets.concatenate_datasets(dataframes)
+dataframe.save_to_disk("~/dataset/combined.parquet")

--- a/orby/data/merge_multitask_parquet.py
+++ b/orby/data/merge_multitask_parquet.py
@@ -1,8 +1,15 @@
+"""This script merges parquet files of different structures into a single parquet file.
+
+Missing fields will be filled with NaN values. Also applies the format fix for subtask
+data so we can fix the issues offline before training.
+"""
+
 import datasets
 from datasets import Sequence, Image
 
 
 def fix_dataset_format_for_merge(dataset):
+    """Copied from orby/utils/dataset/sft_dataset.py"""
     if "images" in dataset.features:
         # Check if images are in Dataset 2 format (list of dicts with bytes/path)
         # Dataset subtask_direct_distill format: [{'bytes': binary, 'path': int32}]
@@ -44,12 +51,12 @@ def fix_dataset_format_for_merge(dataset):
 parquet_files = [
     "/root/subtask/osatlas_test_part_0000.parquet",
     "/root/subtask/osatlas_test_part_0001.parquet",
-    #"/root/subtask/osatlas_test_part_0006.parquet",
-    #"/root/subtask/osatlas_test_part_0007.parquet",
+    "/root/subtask/osatlas_test_part_0006.parquet",
+    "/root/subtask/osatlas_test_part_0007.parquet",
     "/root/subtask/test_part_0000.parquet",
     "/root/subtask/test_part_0001.parquet",
-    #"/root/subtask/test_part_0006.parquet",
-    #"/root/subtask/test_part_0007.parquet",
+    "/root/subtask/test_part_0006.parquet",
+    "/root/subtask/test_part_0007.parquet",
     "/root/subtask/subtask_test.parquet",
 ]
 dataframes = []
@@ -61,5 +68,5 @@ for parquet_file in parquet_files:
     print(dataframe)
 
 dataframe: datasets.Dataset = datasets.concatenate_datasets(dataframes)
-print('Final', dataframe)
+print("Final", dataframe)
 dataframe.to_pandas().to_parquet("/root/subtask/test.parquet", row_group_size=512)

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -5,7 +5,7 @@ image: whatcanyousee/verl:ngc-cu124-vllm0.8.3-sglang0.4.5-mcore0.12.0-te2.2
 integrations:
   - integration_type: git_repo
     git_repo: orby-ai-engineering/verl
-    git_branch: grpo_multitask
+    git_branch: main
     pip_install: .
     ssh_clone: true
 
@@ -16,9 +16,9 @@ compute:
 
 command: |
   # Set these variables before running the script.
-  export EXPERIMENT_NAME="subtask_docker_grounding_1"
+  export EXPERIMENT_NAME="SET EXPERIMENT NAME"
   export PROJECT_NAME=verl_interleaved
-  export MODEL_NAME=Qwen/Qwen2.5-VL-72B-Instruct
+  export MODEL_NAME=Qwen/Qwen2.5-VL-7B-Instruct
   # Set this if you want to skip the initial SFT step and start from a checkpoint
   export BASE_SFT_CHECKPOINT=
 
@@ -36,7 +36,7 @@ command: |
   # 0/train.parquet, 1/train.parquet
   # We use shared validation files for all steps below.
   # Example: https://us-east-1.console.aws.amazon.com/s3/buckets/orby-llm?region=us-east-1&bucketType=general&prefix=interleaved/data/subtask/
-  export INTERLEAVED_DATA_DIR=s3://orby-llm/interleaved/data/subtask_docker_grounding
+  export INTERLEAVED_DATA_DIR=s3://orby-llm/interleaved/data/subtask
 
   # Change these to the initial SFT data files. Currently, it's also downloaded from INTERLEAVED_DATA_DIR
   # which contains sft_train.parquet.
@@ -49,11 +49,12 @@ command: |
   # Rollout batch size 1024 is tested, larger rollout batch size may be feasible, but may cause OOM
   # on the main node as it needs to load the entire rollout batch into memory.
   export NUM_NODES=8
-  export SFT_MICRO_BATCH_SIZE_PER_GPU=1
-  export SFT_TRAIN_BATCH_SIZE=64
+  export SFT_MICRO_BATCH_SIZE_PER_GPU=2
+  export SFT_TRAIN_BATCH_SIZE=128
   export GRPO_MICRO_BATCH_SIZE_PER_GPU=1
   export GRPO_TRAIN_BATCH_SIZE=64
-  export ROLLOUT_BATCH_SIZE=512
+  # For 72B model, set rollout batch size to 512.
+  export ROLLOUT_BATCH_SIZE=1024
 
   # For 72B model, set tensor model parallel size to 8.
   export TENSOR_MODEL_PARALLEL_SIZE=1
@@ -69,7 +70,7 @@ command: |
 
   # Set GRPO parameters
   export REWARD_FN=training_reward_func
-  export REWARD_FILE=orby/reward/multitask.py
+  export REWARD_FILE=orby/reward/subtask.py
   export COORDINATES_METRIC="gaussian"
   export COORDINATES_GAUSSIAN_SIGMA=2
   export COORDINATES_PIXEL_SQUARE_SIZE=10

--- a/orby/mcli/interleaved_pipeline.yaml
+++ b/orby/mcli/interleaved_pipeline.yaml
@@ -5,7 +5,7 @@ image: whatcanyousee/verl:ngc-cu124-vllm0.8.3-sglang0.4.5-mcore0.12.0-te2.2
 integrations:
   - integration_type: git_repo
     git_repo: orby-ai-engineering/verl
-    git_branch: main
+    git_branch: grpo_multitask
     pip_install: .
     ssh_clone: true
 
@@ -16,9 +16,9 @@ compute:
 
 command: |
   # Set these variables before running the script.
-  export EXPERIMENT_NAME="SET EXPERIMENT NAME"
+  export EXPERIMENT_NAME="subtask_docker_grounding_1"
   export PROJECT_NAME=verl_interleaved
-  export MODEL_NAME=Qwen/Qwen2.5-VL-7B-Instruct
+  export MODEL_NAME=Qwen/Qwen2.5-VL-72B-Instruct
   # Set this if you want to skip the initial SFT step and start from a checkpoint
   export BASE_SFT_CHECKPOINT=
 
@@ -36,7 +36,7 @@ command: |
   # 0/train.parquet, 1/train.parquet
   # We use shared validation files for all steps below.
   # Example: https://us-east-1.console.aws.amazon.com/s3/buckets/orby-llm?region=us-east-1&bucketType=general&prefix=interleaved/data/subtask/
-  export INTERLEAVED_DATA_DIR=s3://orby-llm/interleaved/data/subtask
+  export INTERLEAVED_DATA_DIR=s3://orby-llm/interleaved/data/subtask_docker_grounding
 
   # Change these to the initial SFT data files. Currently, it's also downloaded from INTERLEAVED_DATA_DIR
   # which contains sft_train.parquet.
@@ -49,19 +49,27 @@ command: |
   # Rollout batch size 1024 is tested, larger rollout batch size may be feasible, but may cause OOM
   # on the main node as it needs to load the entire rollout batch into memory.
   export NUM_NODES=8
-  export SFT_MICRO_BATCH_SIZE_PER_GPU=2
-  export SFT_TRAIN_BATCH_SIZE=128
+  export SFT_MICRO_BATCH_SIZE_PER_GPU=1
+  export SFT_TRAIN_BATCH_SIZE=64
   export GRPO_MICRO_BATCH_SIZE_PER_GPU=1
   export GRPO_TRAIN_BATCH_SIZE=64
-  export ROLLOUT_BATCH_SIZE=1024
+  export ROLLOUT_BATCH_SIZE=512
+
+  # For 72B model, set tensor model parallel size to 8.
+  export TENSOR_MODEL_PARALLEL_SIZE=1
 
   # Set SFT parameters
   export ATTENTION_DROPOUT=0.0
-  export SFT_LR=1e-5
+  export SFT_LR=1e-6
+  export SFT_CHECKPOINT_INTERVAL=100
+
+  # Set to False as a single merged dataset with unified structure
+  # is used for interleaved training.
+  export CLEAN_DATASET=True
 
   # Set GRPO parameters
   export REWARD_FN=training_reward_func
-  export REWARD_FILE=orby/reward/subtask.py
+  export REWARD_FILE=orby/reward/multitask.py
   export COORDINATES_METRIC="gaussian"
   export COORDINATES_GAUSSIAN_SIGMA=2
   export COORDINATES_PIXEL_SQUARE_SIZE=10
@@ -74,6 +82,9 @@ command: |
   export LOCAL_EVAL_RESULT_FILE=$LOCAL_EVAL_DIR/results.parquet
   export S3_EVAL_RESULT_DIR=s3://orby-llm/interleaved/experiments/$EXPERIMENT_NAME/eval
   export S3_EVAL_RESULT_FILE=$S3_EVAL_RESULT_DIR/results.parquet
+
+  # For 72B model, set eval batch size to 32.
+  export EVAL_STEP_BATCH_SIZE=1024
 
   # Set difficulty filter parameters
   export MEDIUM_DIFFICULTY_FILTER_UPPER_BOUND=0.9

--- a/orby/reward/multitask.py
+++ b/orby/reward/multitask.py
@@ -1,0 +1,41 @@
+"""Reward function that supports multiple tasks."""
+
+
+def training_reward_func(
+    data_source,
+    solution_str,
+    ground_truth,
+    **kwargs,
+):
+    if data_source in ["uground"]:
+        from orby.reward import uground
+
+        return uground.reward_func(data_source, solution_str, ground_truth, **kwargs)
+    elif data_source in ["subtask"]:
+        from orby.reward import subtask
+
+        return subtask.training_reward_func(
+            data_source, solution_str, ground_truth, **kwargs
+        )
+    else:
+        raise NotImplementedError
+
+
+def eval_reward_func(
+    data_source,
+    solution_str,
+    ground_truth,
+    **kwargs,
+):
+    if data_source in ["uground"]:
+        from orby.reward import uground
+
+        return uground.reward_func(data_source, solution_str, ground_truth, **kwargs)
+    elif data_source in ["subtask"]:
+        from orby.reward import subtask
+
+        return subtask.eval_reward_func(
+            data_source, solution_str, ground_truth, **kwargs
+        )
+    else:
+        raise NotImplementedError

--- a/orby/reward/multitask.py
+++ b/orby/reward/multitask.py
@@ -10,7 +10,7 @@ def training_reward_func(
     if data_source in ["uground"]:
         from orby.reward import uground
 
-        return uground.reward_func(
+        scores = uground.reward_func(
             data_source,
             solution_str,
             ground_truth,
@@ -18,10 +18,11 @@ def training_reward_func(
             kwargs.get("use_gaussian"),
             kwargs.get("extra_info"),
         )
+        return {'score': scores['score']}
     elif data_source in ["subtask_direct_distill"]:
         from orby.reward import subtask
 
-        return subtask.training_reward_func(
+        scores = subtask.training_reward_func(
             data_source,
             solution_str,
             ground_truth,
@@ -30,6 +31,7 @@ def training_reward_func(
             kwargs.get("coordinates_pixel_square_size", 10),
             kwargs.get("extra_info"),
         )
+        return {'score': scores['score']}
     else:
         raise NotImplementedError
 

--- a/orby/reward/multitask.py
+++ b/orby/reward/multitask.py
@@ -10,12 +10,25 @@ def training_reward_func(
     if data_source in ["uground"]:
         from orby.reward import uground
 
-        return uground.reward_func(data_source, solution_str, ground_truth, **kwargs)
-    elif data_source in ["subtask"]:
+        return uground.reward_func(
+            data_source,
+            solution_str,
+            ground_truth,
+            kwargs.get("prompt_format"),
+            kwargs.get("use_gaussian"),
+            kwargs.get("extra_info"),
+        )
+    elif data_source in ["subtask_direct_distill"]:
         from orby.reward import subtask
 
         return subtask.training_reward_func(
-            data_source, solution_str, ground_truth, **kwargs
+            data_source,
+            solution_str,
+            ground_truth,
+            kwargs.get("coordinates_metric", "gaussian"),
+            kwargs.get("coordinates_gaussian_sigma", 5),
+            kwargs.get("coordinates_pixel_square_size", 10),
+            kwargs.get("extra_info"),
         )
     else:
         raise NotImplementedError
@@ -30,12 +43,25 @@ def eval_reward_func(
     if data_source in ["uground"]:
         from orby.reward import uground
 
-        return uground.reward_func(data_source, solution_str, ground_truth, **kwargs)
-    elif data_source in ["subtask"]:
+        return uground.reward_func(
+            data_source,
+            solution_str,
+            ground_truth,
+            kwargs.get("prompt_format"),
+            kwargs.get("use_gaussian"),
+            kwargs.get("extra_info"),
+        )
+    elif data_source in ["subtask_direct_distill"]:
         from orby.reward import subtask
 
         return subtask.eval_reward_func(
-            data_source, solution_str, ground_truth, **kwargs
+            data_source,
+            solution_str,
+            ground_truth,
+            kwargs.get("coordinates_metric", "gaussian"),
+            kwargs.get("coordinates_gaussian_sigma", 5),
+            kwargs.get("coordinates_pixel_square_size", 10),
+            kwargs.get("extra_info"),
         )
     else:
         raise NotImplementedError

--- a/orby/reward/multitask.py
+++ b/orby/reward/multitask.py
@@ -18,7 +18,7 @@ def training_reward_func(
             kwargs.get("use_gaussian"),
             kwargs.get("extra_info"),
         )
-        return {'score': scores['score']}
+        return {"score": scores["score"]}
     elif data_source in ["subtask_direct_distill"]:
         from orby.reward import subtask
 
@@ -31,7 +31,7 @@ def training_reward_func(
             kwargs.get("coordinates_pixel_square_size", 10),
             kwargs.get("extra_info"),
         )
-        return {'score': scores['score']}
+        return {"score": scores["score"]}
     else:
         raise NotImplementedError
 

--- a/orby/reward/uground.py
+++ b/orby/reward/uground.py
@@ -28,7 +28,7 @@ class UGroundRewardScorer:
         super().__init__()
         self.thinking_pattern = re.compile(r"<think>(.*?)</think>", re.DOTALL)
         self.answer_pattern = re.compile(r"<answer>(.*?)</answer>", re.DOTALL)
-        self.coordinate_pattern = re.compile(r"(\d*\.?\d+)\s+(\d*\.?\d+)")
+        self.coordinate_pattern = re.compile(r"click\((\d*\.?\d+)[,\s]+(\d*\.?\d+)\)")
 
     def _extract_coordinates(
         self, answer_str: str
@@ -100,7 +100,7 @@ class UGroundRewardScorer:
         coord_score = 1.0 if coordinates_correct else 0.0
 
         # Weight the scores (can be adjusted based on importance)
-        weights = {"format": 0.2, "coordinates": 0.8}
+        weights = {"format": 0.0, "coordinates": 1.0}
 
         overall_score = (
             weights["format"] * format_score + weights["coordinates"] * coord_score

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -121,7 +121,7 @@ generate_rollout_data() {
             rollout.top_p=1.0 \
             rollout.prompt_length=7680 \
             rollout.response_length=512 \
-            rollout.tensor_model_parallel_size=1 \
+            rollout.tensor_model_parallel_size=8 \
             rollout.gpu_memory_utilization=0.9 \
             rollout.max_num_batched_tokens=65536 \
             rollout.n=$n_samples \
@@ -231,7 +231,7 @@ grpo_step() {
         actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
         actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
         actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=8192 \
-        actor_rollout_ref.rollout.tensor_model_parallel_size=4 \
+        actor_rollout_ref.rollout.tensor_model_parallel_size=8 \
         actor_rollout_ref.rollout.name=vllm \
         actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
         actor_rollout_ref.rollout.enable_chunked_prefill=False \
@@ -267,7 +267,7 @@ eval_step() {
         trainer.n_gpus_per_node=8 \
         data.path=$eval_data_path \
         data.prompt_key=prompt \
-        data.batch_size=1024 \
+        data.batch_size=256 \
         +data.max_prompt_length=7680 \
         +data.filter_overlong_prompts=false \
         data.n_samples=1 \
@@ -277,7 +277,7 @@ eval_step() {
         rollout.top_p=1.0 \
         rollout.prompt_length=7680 \
         rollout.response_length=512 \
-        rollout.tensor_model_parallel_size=1 \
+        rollout.tensor_model_parallel_size=8 \
         rollout.gpu_memory_utilization=0.9 \
         rollout.max_num_batched_tokens=65536 \
         +rollout.limit_images=3

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -121,7 +121,7 @@ generate_rollout_data() {
             rollout.top_p=1.0 \
             rollout.prompt_length=7680 \
             rollout.response_length=512 \
-            rollout.tensor_model_parallel_size=8 \
+            rollout.tensor_model_parallel_size=$TENSOR_MODEL_PARALLEL_SIZE \
             rollout.gpu_memory_utilization=0.9 \
             rollout.max_num_batched_tokens=65536 \
             rollout.n=$n_samples \
@@ -159,6 +159,7 @@ sft_step() {
         data.prompt_key=prompt \
         data.response_key=response \
         +data.image_key=images \
+        +data.clean_dataset=$CLEAN_DATASET \
         +processor.use_fast=true \
         +processor.trust_remote_code=true \
         optim.lr=$sft_lr \
@@ -175,8 +176,8 @@ sft_step() {
         trainer.experiment_name=$experiment_name \
         trainer.logger=[console,wandb] \
         trainer.default_hdfs_dir=null \
-        +trainer.val_interval=400 \
-        +trainer.save_interval=400 \
+        +trainer.val_interval=$SFT_CHECKPOINT_INTERVAL \
+        +trainer.save_interval=$SFT_CHECKPOINT_INTERVAL \
         trainer.total_epochs=1 \
         ulysses_sequence_parallel_size=1 \
         use_remove_padding=false \
@@ -231,7 +232,7 @@ grpo_step() {
         actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
         actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
         actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=8192 \
-        actor_rollout_ref.rollout.tensor_model_parallel_size=8 \
+        actor_rollout_ref.rollout.tensor_model_parallel_size=$TENSOR_MODEL_PARALLEL_SIZE \
         actor_rollout_ref.rollout.name=vllm \
         actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
         actor_rollout_ref.rollout.enable_chunked_prefill=False \
@@ -267,7 +268,7 @@ eval_step() {
         trainer.n_gpus_per_node=8 \
         data.path=$eval_data_path \
         data.prompt_key=prompt \
-        data.batch_size=32 \
+        data.batch_size=$EVAL_STEP_BATCH_SIZE \
         +data.max_prompt_length=7680 \
         +data.filter_overlong_prompts=false \
         data.n_samples=1 \
@@ -277,7 +278,7 @@ eval_step() {
         rollout.top_p=1.0 \
         rollout.prompt_length=7680 \
         rollout.response_length=512 \
-        rollout.tensor_model_parallel_size=8 \
+        rollout.tensor_model_parallel_size=$TENSOR_MODEL_PARALLEL_SIZE \
         rollout.gpu_memory_utilization=0.9 \
         rollout.max_num_batched_tokens=65536 \
         +rollout.limit_images=3
@@ -350,7 +351,6 @@ function merge_checkpoint() {
 
     python3 orby/scripts/model_merger.py merge \
         --backend fsdp \
-        --hf_model_path Qwen/Qwen2.5-VL-7B-Instruct \
         --local_dir $max_steps_checkpoint/actor \
         --target_dir $max_steps_checkpoint/hf/
 }

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -267,7 +267,7 @@ eval_step() {
         trainer.n_gpus_per_node=8 \
         data.path=$eval_data_path \
         data.prompt_key=prompt \
-        data.batch_size=256 \
+        data.batch_size=32 \
         +data.max_prompt_length=7680 \
         +data.filter_overlong_prompts=false \
         data.n_samples=1 \

--- a/orby/scripts/interleaved_pipeline.sh
+++ b/orby/scripts/interleaved_pipeline.sh
@@ -175,8 +175,8 @@ sft_step() {
         trainer.experiment_name=$experiment_name \
         trainer.logger=[console,wandb] \
         trainer.default_hdfs_dir=null \
-        +trainer.val_interval=100 \
-        +trainer.save_interval=100 \
+        +trainer.val_interval=400 \
+        +trainer.save_interval=400 \
         trainer.total_epochs=1 \
         ulysses_sequence_parallel_size=1 \
         use_remove_padding=false \

--- a/orby/utils/dataset/sft_dataset.py
+++ b/orby/utils/dataset/sft_dataset.py
@@ -69,34 +69,40 @@ def clean_dataset_for_training(dataset: datasets.Dataset) -> datasets.Dataset:
 
     # TODO: Reconcile the differences in image format and response schema between subtask_direct_distill and uground,os_atlas at the dataset level
     # Standardize image format if needed
-    # if 'images' in dataset.features:
-    #     # Check if images are in Dataset 2 format (list of dicts with bytes/path)
-    #     # Dataset subtask_direct_distill format: [{'bytes': binary, 'path': int32}]
-    #     # Dataset uground,os_atlas format: Sequence(feature=Image(mode=None, decode=True))
-    #     if type(dataset.features['images']) == list:
-    #         logger.info("Converting image format from [{'bytes': binary, 'path': int32}] to Sequence[Image]")
-    #         # Cast the images column to the new Sequence type
-    #         dataset = dataset.cast_column('images', Sequence(feature=Image(decode=True), length=-1))
+    if "images" in dataset.features:
+        # Check if images are in Dataset 2 format (list of dicts with bytes/path)
+        # Dataset subtask_direct_distill format: [{'bytes': binary, 'path': int32}]
+        # Dataset uground,os_atlas format: Sequence(feature=Image(mode=None, decode=True))
+        if type(dataset.features["images"]) == list:
+            logger.info(
+                "Converting image format from [{'bytes': binary, 'path': int32}] to Sequence[Image]"
+            )
+            # Cast the images column to the new Sequence type
+            dataset = dataset.cast_column(
+                "images", Sequence(feature=Image(decode=True), length=-1)
+            )
 
     # In all datasets, the response field is a list of dicts with role and content keys
     # The order of keys is "role" and "content" in subtask_direct_distill dataset, and "content" and "role" in uground,os_atlas dataset
     # This leads to a mismatch in the response schema between the two datasets, which results in a failure to concatenate the two datasets
     # Change response message key order for subtask_direct_distill dataset
-    # if 'data_source' in dataset.features and dataset['data_source'][0] == 'subtask_direct_distill':
-    #     logger.info("Standardizing response message key order")
+    if (
+        "data_source" in dataset.features
+        and dataset["data_source"][0] == "subtask_direct_distill"
+    ):
+        logger.info("Standardizing response message key order")
 
-    #     # Explicitly cast the response column to ensure schema compatibility
-    #     response_features = [{
-    #         "content": datasets.Value("string"),
-    #         "role": datasets.Value("string")
-    #     }]
+        # Explicitly cast the response column to ensure schema compatibility
+        response_features = [
+            {"content": datasets.Value("string"), "role": datasets.Value("string")}
+        ]
 
-    #     # Create new features with the correct order
-    #     new_features = dataset.features.copy()
-    #     new_features["response"] = response_features
+        # Create new features with the correct order
+        new_features = dataset.features.copy()
+        new_features["response"] = response_features
 
-    #     # Cast the dataset to the new schema
-    #     dataset = dataset.cast(new_features)
+        # Cast the dataset to the new schema
+        dataset = dataset.cast(new_features)
 
     logger.info(f"Dataset features: {dataset.features}")
     return dataset
@@ -159,6 +165,7 @@ class SFTDataset(Dataset):
         self.return_full_prompt = config.get("return_full_prompt", False)
         self.truncation = config.get("truncation", "error")
         self.filter_overlong_prompts = config.get("filter_overlong_prompts", True)
+        self.clean_dataset = config.get("clean_dataset", True)
 
         self.num_workers = config.get(
             "filter_overlong_prompts_workers", max(1, os.cpu_count() // 4)
@@ -191,7 +198,8 @@ class SFTDataset(Dataset):
             ]
             # Clean the dataset to remove unnecessary fields
             logger.info(f"Dataset features for {parquet_file}")
-            dataframe = clean_dataset_for_training(dataframe)
+            if self.clean_dataset:
+                dataframe = clean_dataset_for_training(dataframe)
             dataframes.append(dataframe)
         self.dataframe: datasets.Dataset = datasets.concatenate_datasets(dataframes)
 


### PR DESCRIPTION
1. Add multitask reward function -- just return `score` for each task, as different score dict structure will break training
2. Add parquet merge script -- we need to merge grounding and subtask data into 1 parquet for interleaved pipeline
3. Expose more params in interleaved yaml for 72B model (need to reduce batch size etc)